### PR TITLE
Add Shard Path Into Slow Log

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/SearchSlowLog.java
+++ b/server/src/main/java/org/elasticsearch/index/SearchSlowLog.java
@@ -162,6 +162,7 @@ public final class SearchSlowLog implements SearchOperationListener {
         private static Map<String, Object> prepareMap(SearchContext context, long tookInNanos) {
             Map<String, Object> messageFields = new HashMap<>();
             messageFields.put("message", context.indexShard().shardId());
+            messageFields.put("shard_path", context.indexShard().shardPath().getRootDataPath());
             messageFields.put("took", TimeValue.timeValueNanos(tookInNanos));
             messageFields.put("took_millis", TimeUnit.NANOSECONDS.toMillis(tookInNanos));
             if (context.queryResult().getTotalHits() != null) {


### PR DESCRIPTION
It is usually necessary to analyze the disk status to find out whether the disk IO bottleneck made the search slow, so I added shard path information into the search slow log to make the troubleshooting easier.